### PR TITLE
Add admin action logging

### DIFF
--- a/sql/05_admin_logs.sql
+++ b/sql/05_admin_logs.sql
@@ -1,0 +1,10 @@
+-- Table for logging admin actions
+CREATE TABLE IF NOT EXISTS admin_logs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  admin_id UUID REFERENCES profiles(id) ON DELETE SET NULL,
+  action TEXT NOT NULL,
+  entity TEXT,
+  entity_id UUID,
+  details JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/src/app/admin/categories/[id]/page.tsx
+++ b/src/app/admin/categories/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@/lib/supabase";
 import Link from "next/link";
+import { logAdminAction } from "@/lib/utils";
 
 type Category = {
   id: string;
@@ -200,11 +201,23 @@ export default function EditCategoryPage({ params }: { params: { id: string } })
         })
         .eq('id', categoryId)
         .select();
-        
+
       if (error) {
         throw error;
       }
-      
+
+      const { data: { session: logSession } } = await supabase.auth.getSession();
+      if (logSession) {
+        await logAdminAction(
+          supabase,
+          logSession.user.id,
+          'update',
+          'category',
+          categoryId,
+          { name: formData.name }
+        );
+      }
+
       // Redirect to categories page
       router.push('/admin/categories');
       
@@ -253,11 +266,23 @@ export default function EditCategoryPage({ params }: { params: { id: string } })
         .from('categories')
         .delete()
         .eq('id', categoryId);
-        
+
       if (error) {
         throw error;
       }
-      
+
+      const { data: { session: logSession } } = await supabase.auth.getSession();
+      if (logSession) {
+        await logAdminAction(
+          supabase,
+          logSession.user.id,
+          'delete',
+          'category',
+          categoryId,
+          {}
+        );
+      }
+
       // Redirect to categories page
       router.push('/admin/categories');
       

--- a/src/app/admin/categories/new/page.tsx
+++ b/src/app/admin/categories/new/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClientComponentClient } from "@/lib/supabase";
 import Link from "next/link";
+import { logAdminAction } from "@/lib/utils";
 
 type Category = {
   id: string;
@@ -156,9 +157,22 @@ export default function NewCategoryPage() {
           },
         ])
         .select();
-        
+
       if (error) {
         throw error;
+      }
+
+      const newId = data?.[0]?.id || null;
+      const { data: { session: logSession } } = await supabase.auth.getSession();
+      if (logSession) {
+        await logAdminAction(
+          supabase,
+          logSession.user.id,
+          'create',
+          'category',
+          newId,
+          { name: formData.name }
+        );
       }
       
       // Redirect to categories page

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -557,46 +557,47 @@ export default function AdminDashboardPage() {
         });
       }
       
-      // Fetch recent activity (simplified example - could be from orders, products updates, etc.)
-      const { data: recentOrders, error: activityError } = await supabase
-        .from('orders')
+      // Fetch recent admin activity
+      const { data: logs, error: activityError } = await supabase
+        .from('admin_logs')
         .select(`
-          id, 
-          status, 
-          created_at, 
-          user_id,
-          profiles!user_id(first_name, last_name, email)
+          id,
+          action,
+          entity,
+          entity_id,
+          details,
+          created_at,
+          profiles!admin_id(first_name, last_name, email)
         `)
         .order('created_at', { ascending: false })
-        .limit(3);
-        
-      if (!activityError && recentOrders) {
-        // Cast data to any to help with TypeScript
-        const ordersData: any[] = recentOrders;
-        
-        const activities = ordersData.map(order => {
-          // Get profile from the order
-          const profile = order.profiles;
-          
-          // Build user name/email text
-          let userText = 'Misafir Kullanıcı';
+        .limit(5);
+
+      if (!activityError && logs) {
+        const activities = logs.map((log: any) => {
+          const profile = log.profiles;
+          let adminText = 'Admin';
           if (profile) {
             if (profile.first_name && profile.last_name) {
-              userText = `${profile.first_name} ${profile.last_name}`;
+              adminText = `${profile.first_name} ${profile.last_name}`;
             } else if (profile.email) {
-              userText = profile.email;
+              adminText = profile.email;
             }
           }
-          
+
+          let content = `${adminText} ${log.action}`;
+          if (log.details?.name) {
+            content += ` ${log.details.name}`;
+          }
+
           return {
-            id: order.id,
-            title: `Yeni Sipariş`,
-            content: `${userText} bir sipariş verdi`,
-            time: formatTimeAgo(new Date(order.created_at)),
-            type: 'order'
+            id: log.id,
+            title: log.action,
+            content,
+            time: formatTimeAgo(new Date(log.created_at)),
+            type: log.entity
           };
         });
-        
+
         setActivities(activities);
       }
       
@@ -637,6 +638,18 @@ export default function AdminDashboardPage() {
         return (
           <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+          </svg>
+        );
+      case 'category':
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+          </svg>
+        );
+      case 'user':
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5.121 17.804A7 7 0 0112 15a7 7 0 016.879 2.804M15 10a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
         );
       default:

--- a/src/app/admin/products/edit/[id]/page.tsx
+++ b/src/app/admin/products/edit/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@/lib/supabase";
 import Link from "next/link";
-import { generateSlug, generateUniqueSlug, generateUniqueSku } from "@/lib/utils";
+import { generateSlug, generateUniqueSlug, generateUniqueSku, logAdminAction } from "@/lib/utils";
 
 export default function EditProductPage({ params }: { params: { id: string } }) {
   const productId = params.id;
@@ -366,6 +366,18 @@ export default function EditProductPage({ params }: { params: { id: string } }) 
             }
           }
         }
+      }
+
+      const { data: { session: logSession } } = await supabase.auth.getSession();
+      if (logSession) {
+        await logAdminAction(
+          supabase,
+          logSession.user.id,
+          'update',
+          'product',
+          productId,
+          { name: formData.name }
+        );
       }
 
       setSuccess(true);

--- a/src/app/admin/products/new/page.tsx
+++ b/src/app/admin/products/new/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@/lib/supabase";
 import Link from "next/link";
-import { generateSlug, generateUniqueSlug, generateUniqueSku } from "@/lib/utils";
+import { generateSlug, generateUniqueSlug, generateUniqueSku, logAdminAction } from "@/lib/utils";
 
 export default function NewProductPage() {
   const [isLoading, setIsLoading] = useState(false);
@@ -181,6 +181,18 @@ export default function NewProductPage() {
 
       if (!productData) {
         throw new Error("Ürün kaydedilemedi.");
+      }
+
+      const { data: { session: logSession } } = await supabase.auth.getSession();
+      if (logSession) {
+        await logAdminAction(
+          supabase,
+          logSession.user.id,
+          'create',
+          'product',
+          productData,
+          { name: formData.name }
+        );
       }
 
       // Upload images if available

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { createClientComponentClient } from "@/lib/supabase";
 import { useRouter } from "next/navigation";
+import { logAdminAction } from "@/lib/utils";
 
 export default function AdminProductsPage() {
   const [products, setProducts] = useState<any[]>([]);
@@ -148,17 +149,29 @@ export default function AdminProductsPage() {
             .from('product_images')
             .delete()
             .in('product_id', selectedProducts);
-            
+
           // Then delete the products
           const { error } = await supabase
             .from('products')
             .delete()
             .in('id', selectedProducts);
-            
+
           if (error) throw error;
-          
+
         setProducts(products.filter((p) => !selectedProducts.includes(p.id)));
         setSelectedProducts([]);
+
+        const { data: { session: delSession } } = await supabase.auth.getSession();
+        if (delSession) {
+          await logAdminAction(
+            supabase,
+            delSession.user.id,
+            'delete',
+            'product',
+            null,
+            { ids: selectedProducts }
+          );
+        }
         break;
           
       case "activate":
@@ -174,6 +187,19 @@ export default function AdminProductsPage() {
               selectedProducts.includes(p.id) ? { ...p, is_active: true } : p,
           ),
         );
+        {
+          const { data: { session: actSession } } = await supabase.auth.getSession();
+          if (actSession) {
+            await logAdminAction(
+              supabase,
+              actSession.user.id,
+              'activate',
+              'product',
+              null,
+              { ids: selectedProducts }
+            );
+          }
+        }
         break;
           
       case "deactivate":
@@ -189,6 +215,19 @@ export default function AdminProductsPage() {
               selectedProducts.includes(p.id) ? { ...p, is_active: false } : p,
           ),
         );
+        {
+          const { data: { session: deactSession } } = await supabase.auth.getSession();
+          if (deactSession) {
+            await logAdminAction(
+              supabase,
+              deactSession.user.id,
+              'deactivate',
+              'product',
+              null,
+              { ids: selectedProducts }
+            );
+          }
+        }
         break;
           
       default:

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -81,6 +81,35 @@ export interface Database {
           created_at?: string
         }
       }
+      admin_logs: {
+        Row: {
+          id: string
+          admin_id: string | null
+          action: string
+          entity: string | null
+          entity_id: string | null
+          details: Json | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          admin_id?: string | null
+          action: string
+          entity?: string | null
+          entity_id?: string | null
+          details?: Json | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          admin_id?: string | null
+          action?: string
+          entity?: string | null
+          entity_id?: string | null
+          details?: Json | null
+          created_at?: string
+        }
+      }
       // Diğer tablolar da eklenebilir
     }
   }
@@ -88,4 +117,6 @@ export interface Database {
 
 export type Profile = Database['public']['Tables']['profiles']['Row']
 
-export type DebugLog = Database['public']['Tables']['debug_logs']['Row'] 
+export type DebugLog = Database['public']['Tables']['debug_logs']['Row']
+
+export type AdminLog = Database['public']['Tables']['admin_logs']['Row']

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { createClientComponentClient } from "./supabase";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -81,4 +82,28 @@ export function generateUniqueSku(baseSku: string): string {
  */
 export function normalizeSlug(slug: string): string {
   return slug.toLowerCase().trim();
-} 
+}
+
+/**
+ * Inserts a record into the admin_logs table
+ */
+export async function logAdminAction(
+  supabase: ReturnType<typeof createClientComponentClient>,
+  adminId: string,
+  action: string,
+  entity: string,
+  entityId: string | null,
+  details: Record<string, any> = {}
+) {
+  try {
+    await supabase.from('admin_logs').insert({
+      admin_id: adminId,
+      action,
+      entity,
+      entity_id: entityId,
+      details,
+    });
+  } catch (e) {
+    console.error('Failed to log admin action', e);
+  }
+}


### PR DESCRIPTION
## Summary
- track admin actions with new `admin_logs` table
- expose `logAdminAction` helper and database types
- log product and category changes across admin pages
- surface admin activity on dashboard

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684304d20ac483319d54dee77a45f02e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced logging of administrative actions for categories and products, including creation, updates, deletions, and bulk operations.
  - Added a recent admin activity feed to the admin dashboard, displaying logged actions with relevant details and icons.

- **Bug Fixes**
  - None.

- **Chores**
  - Improved internal tracking of admin activities for enhanced transparency and auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->