### PR TITLE
Add Jest setup and example tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# E-commerce App
+
+This project is a Next.js based e-commerce application.
+
+## Running Tests
+
+The project uses **Jest** with **React Testing Library** for testing.
+
+Install dependencies and run:
+
+```bash
+npm test
+```
+
+To watch files and re-run tests on change:
+
+```bash
+npm run test:watch
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "keywords": [
     "ecommerce",
@@ -47,6 +49,11 @@
     "eslint-config-next": "^14.0.4",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/app/api/verify-email/__tests__/route.test.ts
+++ b/src/app/api/verify-email/__tests__/route.test.ts
@@ -1,0 +1,9 @@
+import { GET } from '../route';
+
+describe('verify-email API', () => {
+  it('returns 400 when token is missing', async () => {
+    const request = { url: 'http://localhost/api/verify-email' } as any;
+    const response = await GET(request);
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/components/ui/__tests__/Notification.test.tsx
+++ b/src/components/ui/__tests__/Notification.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Notification from '../Notification';
+
+describe('Notification component', () => {
+  it('renders the provided message', () => {
+    render(<Notification message="Hello" />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('closes when the button is clicked', () => {
+    render(<Notification message="Close me" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('Close me')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest and React Testing Library
- add initial Notification component test
- add verify-email API route test
- add npm test scripts and testing dependencies
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:watch` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843033c98b08331980d8afc9ecf4331